### PR TITLE
Replace deprecated Codecov action parameter 'file' with 'files'

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: codecov/codecov-action@v5
       if: runner.os == 'Linux'
       with:
-        file: ./coverage.cobertura.xml
+        files: ./coverage.cobertura.xml
       env:
         CODECOV_TOKEN: ${{ inputs.codecov_token }}
     # NOTE: separate multiple SARIF uploads to add categories. see https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/


### PR DESCRIPTION
https://github.com/codecov/codecov-action/blob/96b38e9e60ee60a8c3911f4612407bba2f9195fb/README.md

>> [!WARNING]
>> **The following arguments have been changed**
>> - `file` (this has been deprecated in favor of `files`)
>> - `plugin` (this has been deprecated in favor of `plugins`)